### PR TITLE
Update to current API (solves #1)

### DIFF
--- a/watson-streaming-stt/speech.cfg
+++ b/watson-streaming-stt/speech.cfg
@@ -2,3 +2,4 @@
 apikey = <YOUR API KEY>
 # Modify region based on where you provisioned your stt instance
 region = <YOUR REGION>
+instance_id = <YOUR INSTANCE ID>

--- a/watson-streaming-stt/transcribe.py
+++ b/watson-streaming-stt/transcribe.py
@@ -171,8 +171,8 @@ def get_url():
     # for details on which endpoints are for each region.
     region = config.get('auth', 'region')
     host = REGION_MAP[region]
-    return ("wss://{}/speech-to-text/api/v1/recognize"
-           "?model=en-AU_BroadbandModel").format(host)
+    instance_id = REGION_MAP[instance_id]
+    return ("wss://api.{}.speech-to-text.watson.cloud.ibm.com/instances/{}/v1/recognize?model=en-AU_BroadbandModel").format(host, instance_id)
 
 def get_auth():
     config = configparser.RawConfigParser()


### PR DESCRIPTION
Hey,
apparently, there were some changes to the API calls, and now we are required to inform our instance_id, causing the 403 error. I was able to fix this in a few lines of code.

Best regards